### PR TITLE
chore(examples): -H -> -P for proxyHost option in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Examples:
                                             listening on 192.168.0.1:8080/app.
                                             Ex: GET /hello => http://192.168.0.1
                                             :8080/app/hello
-  http-proxy -H https://www.google.co.uk    Forwards all requests to the server
+  http-proxy -P https://www.google.co.uk    Forwards all requests to the server
                                             listening on www.google.co.uk via
                                             HTTPS.
                                             Ex: GET / => https://www.google.co.

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ export default function (args) {
 
     Ex: GET /hello => http://192.168.0.1:8080/app/hello
   `))
-  .example('$0 -H https://www.google.co.uk', dedent(`
+  .example('$0 -P https://www.google.co.uk', dedent(`
     Forwards all requests to the server listening on www.google.co.uk via HTTPS.
 
     Ex: GET / => https://www.google.co.uk/


### PR DESCRIPTION
In https://github.com/foss-haas/http-proxy-cli/commit/d2abe58f945242078058178a53f0e130596c6797 option to enable `proxyHost` was renamed from `-H` to `-P` but examples were not updated accordingly.