### PR TITLE
Change lib/ to src/ in package.json files section

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "files": [
     "bin/",
-    "lib/",
+    "src/",
     "LICENSE",
     "README.md",
     "package.json"


### PR DESCRIPTION
Here's what I see when install the package:

```sh
$ ls node_modules/http-proxy-cli/                                                                                
bin/                              
LICENSE                           
node_modules/                     
package.json                      
README.md                         
src/                              

$ ls node_modules/http-proxy-cli/src/                          
index.js
```

This change should include the other files in `src/`. I think this should also fix https://github.com/foss-haas/http-proxy-cli/issues/3.